### PR TITLE
Integration tests now use H2 instead of Postgres.

### DIFF
--- a/backend/jobapplicationbackend/src/main/resources/application-test.yml
+++ b/backend/jobapplicationbackend/src/main/resources/application-test.yml
@@ -1,20 +1,11 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/jobapptracker
-    username:
-    password:
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb
+    username: testuser
+    password: testpassword
+    driver-class-name: org.h2.Driver
   jpa:
-    hibernate:
-      ddl-auto: create-drop
-      naming:
-        physical-strategy: com.jpettit.jobapplicationbackend.config.namingstrats.EnvironmentNamingStrategy
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-    database: postgresql
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: org.hibernate.dialect.H2Dialect
 
 tabledata:
   env: test


### PR DESCRIPTION
1. Integration tests use H2 instead of Postgres. There is an issue when running integration tests on GitHub Actions. H2 might be able to fix the problem.