### PR TITLE
Store encryption key in environment variable instead of plaintext

### DIFF
--- a/.github/workflows/jobappcicd.yml
+++ b/.github/workflows/jobappcicd.yml
@@ -57,4 +57,6 @@ jobs:
         cache: gradle
     - name: Build project and test
       working-directory: backend/jobapplicationbackend
+      env:
+        JOBAPP_ENCRYPTKEY: ${{ secrets.JOBAPP_ENCRYPTKEY }}
       run: ./gradlew clean build --stacktrace

--- a/backend/jobapplicationbackend/build.gradle
+++ b/backend/jobapplicationbackend/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.0.5'
-	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.springframework.boot' version '3.2.1'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.jpettit'

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/config/ApplicationConfig.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/config/ApplicationConfig.java
@@ -2,7 +2,6 @@ package com.jpettit.jobapplicationbackend.config;
 
 import com.jpettit.jobapplicationbackend.repos.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -18,9 +17,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 @RequiredArgsConstructor
 public class ApplicationConfig {
-
-    @Value("${tabledata.env}")
-    public static String env;
 
     private final UserRepository userRepository;
 

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/config/SecurityConfig.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -21,17 +22,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                .csrf()
-                .disable()
-                .authorizeHttpRequests()
-                .requestMatchers(Routes.BaseRoutes.allAuthRoutes, Routes.BaseRoutes.allMainRoutes)
-                .permitAll()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(Routes.BaseRoutes.allAuthRoutes, Routes.BaseRoutes.allMainRoutes)
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/enums/EnvironmentVars.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/enums/EnvironmentVars.java
@@ -3,8 +3,7 @@ package com.jpettit.jobapplicationbackend.enums;
 public enum EnvironmentVars {
     JOBAPP_DBUSER("JOBAPP_DBUSER"),
     JOBAPP_DBPASSWORD("JOBAPP_DBPASSWORD"),
-    JOBAPP_SECRETKEY("JOBAPP_ENCRYPTKEY"),
-    JOBAPP_SECRETKEY2("JOBAPP_ENCRYPTKEY2");
+    JOBAPP_SECRETKEY("JOBAPP_ENCRYPTKEY");
 
     private final String value;
 

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/enums/EnvironmentVars.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/enums/EnvironmentVars.java
@@ -1,0 +1,18 @@
+package com.jpettit.jobapplicationbackend.enums;
+
+public enum EnvironmentVars {
+    JOBAPP_DBUSER("JOBAPP_DBUSER"),
+    JOBAPP_DBPASSWORD("JOBAPP_DBPASSWORD"),
+    JOBAPP_SECRETKEY("JOBAPP_ENCRYPTKEY"),
+    JOBAPP_SECRETKEY2("JOBAPP_ENCRYPTKEY2");
+
+    private final String value;
+
+    EnvironmentVars(String envVar) {
+        this.value = envVar;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/services/EnvironmentService.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/services/EnvironmentService.java
@@ -1,0 +1,21 @@
+package com.jpettit.jobapplicationbackend.services;
+
+import com.jpettit.jobapplicationbackend.enums.EnvironmentVars;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnvironmentService {
+
+    private final Environment environment;
+
+    @Autowired
+    public EnvironmentService(final Environment environment) {
+        this.environment = environment;
+    }
+
+    public String getEnvironmentVarOrDefault(final EnvironmentVars key, final String defaultValue) {
+        return environment.getProperty(key.getValue(), defaultValue);
+    }
+}

--- a/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/services/JwtService.java
+++ b/backend/jobapplicationbackend/src/main/java/com/jpettit/jobapplicationbackend/services/JwtService.java
@@ -75,16 +75,8 @@ public class JwtService {
         return extractClaim(token, Claims::getExpiration);
     }
 
-    private int getKeySize(final String key) {
-        return key.length();
-    }
-
     private Key getSignInKey() {
         final String secretKey = environmentService.getEnvironmentVarOrDefault(EnvironmentVars.JOBAPP_SECRETKEY, "");
-        final String secretKey2 = environmentService.getEnvironmentVarOrDefault(EnvironmentVars.JOBAPP_SECRETKEY2, "");
-
-        System.out.println("Secret key length is " + getKeySize(secretKey));
-        System.out.println("Secret key 2 length is " + getKeySize(secretKey2));
 
         if (secretKey.equals("")) {
             final String message = "Couldn't get secret key.";


### PR DESCRIPTION
The encryption key used for encrypting JWTs was stored in plaintext. The project now stores the encryption key in an environment variable rather than storing it in plaintext.